### PR TITLE
add missing dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,19 @@
 See: https://www.gatsbyjs.org/blog/2019-02-26-getting-started-with-gatsby-themes/
 
 Thanks you @KatieofCode  :purple_heart:
+
+## How to use this repo
+
+```
+# Clone the repo
+git clone ggit@github.com:maxpou/gatsby-themes-tutorial.git
+
+# Move into the new directory
+cd gatsby-themes-tutorial/
+
+# Install dependencies
+yarn
+
+# Start the site on http://localhost:8000
+yarn workspace site dev
+```

--- a/packages/theme/src/pages/index.mdx
+++ b/packages/theme/src/pages/index.mdx
@@ -1,0 +1,3 @@
+import { Header } from 'theme';
+
+<Header>This is just a placeholder. The parent folder 'pages' is required to start gatsby. `gatsby-themes-tutorial/site/src/pages/index.mdx` overrides this file.</Header>


### PR DESCRIPTION
The `theme/src/pages` folder was missing and I was unable to start gatsby. This just adds it in with a placeholder `index.mdx` in case others come across this repo why trying to learn Gatsby.

Cheers!